### PR TITLE
Patch wp_delete_file_from_directory

### DIFF
--- a/patch.php
+++ b/patch.php
@@ -4,6 +4,8 @@ define('PATCHES_DIR', __DIR__ . '/patches' );
 require_once __DIR__ . '/wordpress/wp-includes/version.php';
 chdir(__DIR__ . "/wordpress");
 
+patch('real_path_5.1.diff', '5.1-rc1');
+patch('real_path_5.0.diff', '5.0', '5.1-rc1');
 patch('oem_preload_5.1.diff', '5.1-rc1');
 patch('oem_preload_5.0.diff', '5.0', '5.1-rc1');
 patch('imagick_5.1.diff', '5.1-rc1');

--- a/patches/real_path_5.0.diff
+++ b/patches/real_path_5.0.diff
@@ -1,17 +1,16 @@
 diff --git wordpress-orig/wp-includes/functions.php wordpress/wp-includes/functions.php
-index 098079577e..2574ba6c32 100644
+index 58a00528a9..48da45c80f 100644
 --- wordpress-orig/wp-includes/functions.php
 +++ wordpress/wp-includes/functions.php
-@@ -6175,10 +6175,19 @@ function wp_delete_file( $file ) {
+@@ -5602,10 +5602,19 @@ function wp_delete_file( $file ) {
   * @return bool True on success, false on failure.
   */
  function wp_delete_file_from_directory( $file, $directory ) {
--	$real_file      = realpath( wp_normalize_path( $file ) );
+-	$real_file = realpath( wp_normalize_path( $file ) );
 -	$real_directory = realpath( wp_normalize_path( $directory ) );
 +	$file_path      = wp_normalize_path( $file ) ;
 +	$directory_path = wp_normalize_path( $directory ) ;
-
--	if ( false === $real_file || false === $real_directory || strpos( wp_normalize_path( $real_file ), trailingslashit( wp_normalize_path( $real_directory ) ) ) !== 0 ) {
++
 +	if ( ! wp_is_stream( $file ) ) {
 +		$real_file      = realpath( $file_path );
 +		$real_directory = realpath( $directory_path );
@@ -20,7 +19,8 @@ index 098079577e..2574ba6c32 100644
 +			return false;
 +		}
 +	}
-+
+
+-	if ( false === $real_file || false === $real_directory || strpos( wp_normalize_path( $real_file ), trailingslashit( wp_normalize_path( $real_directory ) ) ) !== 0 ) {
 +	if ( strpos( $file_path, trailingslashit( $directory_path ) ) !== 0 ) {
  		return false;
  	}

--- a/patches/real_path_5.0.diff
+++ b/patches/real_path_5.0.diff
@@ -2,26 +2,14 @@ diff --git wordpress-orig/wp-includes/functions.php wordpress/wp-includes/functi
 index 58a00528a9..48da45c80f 100644
 --- wordpress-orig/wp-includes/functions.php
 +++ wordpress/wp-includes/functions.php
-@@ -5602,10 +5602,19 @@ function wp_delete_file( $file ) {
+@@ -5602,8 +5602,8 @@ function wp_delete_file( $file ) {
   * @return bool True on success, false on failure.
   */
  function wp_delete_file_from_directory( $file, $directory ) {
 -	$real_file = realpath( wp_normalize_path( $file ) );
 -	$real_directory = realpath( wp_normalize_path( $directory ) );
-+	$file_path      = wp_normalize_path( $file ) ;
-+	$directory_path = wp_normalize_path( $directory ) ;
-+
-+	if ( ! wp_is_stream( $file ) ) {
-+		$real_file      = realpath( $file_path );
-+		$real_directory = realpath( $directory_path );
-+
-+		if ( false === $real_file || false === $real_directory || strpos( wp_normalize_path( $real_file ), trailingslashit( wp_normalize_path( $real_directory ) ) ) !== 0 ) {
-+			return false;
-+		}
-+	}
-
--	if ( false === $real_file || false === $real_directory || strpos( wp_normalize_path( $real_file ), trailingslashit( wp_normalize_path( $real_directory ) ) ) !== 0 ) {
-+	if ( strpos( $file_path, trailingslashit( $directory_path ) ) !== 0 ) {
++	$real_file = wp_is_stream( $file ) ? wp_normalize_path( $file ) : realpath( wp_normalize_path( $file ) );
++	$real_directory = wp_is_stream( $directory ) ? wp_normalize_path( $directory ) : realpath( wp_normalize_path( $directory ) );
+ 
+ 	if ( false === $real_file || false === $real_directory || strpos( wp_normalize_path( $real_file ), trailingslashit( wp_normalize_path( $real_directory ) ) ) !== 0 ) {
  		return false;
- 	}
-

--- a/patches/real_path_5.0.diff
+++ b/patches/real_path_5.0.diff
@@ -1,0 +1,27 @@
+diff --git wordpress-orig/wp-includes/functions.php wordpress/wp-includes/functions.php
+index 098079577e..2574ba6c32 100644
+--- wordpress-orig/wp-includes/functions.php
++++ wordpress/wp-includes/functions.php
+@@ -6175,10 +6175,19 @@ function wp_delete_file( $file ) {
+  * @return bool True on success, false on failure.
+  */
+ function wp_delete_file_from_directory( $file, $directory ) {
+-	$real_file      = realpath( wp_normalize_path( $file ) );
+-	$real_directory = realpath( wp_normalize_path( $directory ) );
++	$file_path      = wp_normalize_path( $file ) ;
++	$directory_path = wp_normalize_path( $directory ) ;
+
+-	if ( false === $real_file || false === $real_directory || strpos( wp_normalize_path( $real_file ), trailingslashit( wp_normalize_path( $real_directory ) ) ) !== 0 ) {
++	if ( ! wp_is_stream( $file ) ) {
++		$real_file      = realpath( $file_path );
++		$real_directory = realpath( $directory_path );
++
++		if ( false === $real_file || false === $real_directory || strpos( wp_normalize_path( $real_file ), trailingslashit( wp_normalize_path( $real_directory ) ) ) !== 0 ) {
++			return false;
++		}
++	}
++
++	if ( strpos( $file_path, trailingslashit( $directory_path ) ) !== 0 ) {
+ 		return false;
+ 	}
+

--- a/patches/real_path_5.1.diff
+++ b/patches/real_path_5.1.diff
@@ -2,26 +2,15 @@ diff --git wordpress-orig/wp-includes/functions.php wordpress/wp-includes/functi
 index 098079577e..2574ba6c32 100644
 --- wordpress-orig/wp-includes/functions.php
 +++ wordpress/wp-includes/functions.php
-@@ -6175,10 +6175,19 @@ function wp_delete_file( $file ) {
+@@ -6175,8 +6175,8 @@ function wp_delete_file( $file ) {
   * @return bool True on success, false on failure.
   */
  function wp_delete_file_from_directory( $file, $directory ) {
 -	$real_file      = realpath( wp_normalize_path( $file ) );
 -	$real_directory = realpath( wp_normalize_path( $directory ) );
-+	$file_path      = wp_normalize_path( $file ) ;
-+	$directory_path = wp_normalize_path( $directory ) ;
++	$real_file      = wp_is_stream( $file ) ? wp_normalize_path( $file ) : realpath( wp_normalize_path( $file ) );
++	$real_directory = wp_is_stream( $directory ) ? wp_normalize_path( $directory ) : realpath( wp_normalize_path( $directory ) );
 
--	if ( false === $real_file || false === $real_directory || strpos( wp_normalize_path( $real_file ), trailingslashit( wp_normalize_path( $real_directory ) ) ) !== 0 ) {
-+	if ( ! wp_is_stream( $file ) ) {
-+		$real_file      = realpath( $file_path );
-+		$real_directory = realpath( $directory_path );
-+
-+		if ( false === $real_file || false === $real_directory || strpos( wp_normalize_path( $real_file ), trailingslashit( wp_normalize_path( $real_directory ) ) ) !== 0 ) {
-+			return false;
-+		}
-+	}
-+
-+	if ( strpos( $file_path, trailingslashit( $directory_path ) ) !== 0 ) {
- 		return false;
- 	}
+	if ( false === $real_file || false === $real_directory || strpos( wp_normalize_path( $real_file ), trailingslashit( wp_normalize_path( $real_directory ) ) ) !== 0 ) {
+		return false;
 

--- a/patches/real_path_5.1.diff
+++ b/patches/real_path_5.1.diff
@@ -1,0 +1,27 @@
+diff --git wordpress-orig/wp-includes/functions.php wordpress/wp-includes/functions.php
+index 098079577e..2574ba6c32 100644
+--- wordpress-orig/wp-includes/functions.php
++++ wordpress/wp-includes/functions.php
+@@ -6175,10 +6175,19 @@ function wp_delete_file( $file ) {
+  * @return bool True on success, false on failure.
+  */
+ function wp_delete_file_from_directory( $file, $directory ) {
+-	$real_file      = realpath( wp_normalize_path( $file ) );
+-	$real_directory = realpath( wp_normalize_path( $directory ) );
++	$file_path      = wp_normalize_path( $file ) ;
++	$directory_path = wp_normalize_path( $directory ) ;
+
+-	if ( false === $real_file || false === $real_directory || strpos( wp_normalize_path( $real_file ), trailingslashit( wp_normalize_path( $real_directory ) ) ) !== 0 ) {
++	if ( ! wp_is_stream( $file ) ) {
++		$real_file      = realpath( $file_path );
++		$real_directory = realpath( $directory_path );
++
++		if ( false === $real_file || false === $real_directory || strpos( wp_normalize_path( $real_file ), trailingslashit( wp_normalize_path( $real_directory ) ) ) !== 0 ) {
++			return false;
++		}
++	}
++
++	if ( strpos( $file_path, trailingslashit( $directory_path ) ) !== 0 ) {
+ 		return false;
+ 	}
+


### PR DESCRIPTION
Check if the file to delete uses stream wrappers. If so, don't check it's `realpath` since PHP doesn't support stream wrappers in `realpath` implementation.